### PR TITLE
:alien: Update getting single Paw request

### DIFF
--- a/JavaScriptFetchGenerator.js
+++ b/JavaScriptFetchGenerator.js
@@ -25,7 +25,7 @@ class JavaScriptFetchGenerator {
 
 	generate(context, requests) {
 		if (!Array.isArray(requests)) {
-			requests = [requests];
+			requests = [context.getCurrentRequest()];
 		}
 
 		let code = '';


### PR DESCRIPTION
The extension was giving `JS Exception Line 36. TypeError: undefined is not an object (evaluating 'request.getLastExchange')` error when you try to generate a `fetch` request code. This PR fixes that.